### PR TITLE
Added `top_module` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The primary goal of `rules_verilog` is to provide only the most **foundational**
 - `includes` — include search paths (auto-derived from `hdrs` locations + explicit paths)
 - `data` — data files needed during compilation or simulation
 - `deps` — other `verilog_library` targets
-- `module_name` — top-level module name (optional; empty string means "unspecified")
+- `top_module` — the top module of this library (optional; empty string means "unspecified")
 - `standard` — Verilog/SystemVerilog standard version (optional; empty string means "unspecified")
 
 and propagates a transitive `VerilogInfo` provider that downstream rules can consume, like [rules_verilator](https://github.com/MrAMS/bazel_rules_verilator) and [rules_vivado](https://github.com/CruxML/bazel_rules_vivado).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The primary goal of `rules_verilog` is to provide only the most **foundational**
 - `includes` — include search paths (auto-derived from `hdrs` locations + explicit paths)
 - `data` — data files needed during compilation or simulation
 - `deps` — other `verilog_library` targets
+- `module_name` — top-level module name (optional; empty string means "unspecified")
 - `standard` — Verilog/SystemVerilog standard version (optional; empty string means "unspecified")
 
 and propagates a transitive `VerilogInfo` provider that downstream rules can consume, like [rules_verilator](https://github.com/MrAMS/bazel_rules_verilator) and [rules_vivado](https://github.com/CruxML/bazel_rules_vivado).

--- a/verilog/private/tests/BUILD.bazel
+++ b/verilog/private/tests/BUILD.bazel
@@ -41,12 +41,12 @@ verilog_library(
 )
 
 verilog_library(
-    name = "explicit_module_name",
+    name = "explicit_top_module",
     srcs = [
         "dep_a.sv",
         "dep_b.sv",
     ],
-    module_name = "dep_a",
+    top_module = "dep_a",
 )
 
 verilog_library(

--- a/verilog/private/tests/BUILD.bazel
+++ b/verilog/private/tests/BUILD.bazel
@@ -41,12 +41,12 @@ verilog_library(
 )
 
 verilog_library(
-    name = "explicit_top",
+    name = "explicit_module_name",
     srcs = [
         "dep_a.sv",
         "dep_b.sv",
     ],
-    top = "dep_a.sv",
+    module_name = "dep_a",
 )
 
 verilog_library(

--- a/verilog/private/tests/BUILD.bazel
+++ b/verilog/private/tests/BUILD.bazel
@@ -41,6 +41,23 @@ verilog_library(
 )
 
 verilog_library(
+    name = "explicit_top",
+    srcs = [
+        "dep_a.sv",
+        "dep_b.sv",
+    ],
+    top = "dep_a.sv",
+)
+
+verilog_library(
+    name = "utility_lib",
+    srcs = [
+        "dep_a.sv",
+        "dep_b.sv",
+    ],
+)
+
+verilog_library(
     name = "bad_src",
     srcs = ["invalid.txt"],
     tags = ["manual"],

--- a/verilog/private/tests/verilog_library_analysis_test.bzl
+++ b/verilog/private/tests/verilog_library_analysis_test.bzl
@@ -17,7 +17,7 @@ def _leaf_provider_test_impl(ctx):
     asserts.equals(env, [], info.deps.to_list())
     asserts.equals(env, "", info.standard)
     asserts.equals(env, 1, len(info.includes.to_list()))
-    asserts.equals(env, "leaf.sv", info.top.basename)
+    asserts.equals(env, "", info.module_name)
 
     return analysistest.end(env)
 
@@ -58,33 +58,23 @@ def _explicit_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-def _top_name_matching_test_impl(ctx):
-    """Test that top is resolved by matching basename to label name."""
+def _module_name_explicit_test_impl(ctx):
+    """Test that an explicit module_name attribute is used."""
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
     info = target[VerilogInfo]
 
-    asserts.equals(env, "top.sv", info.top.basename)
+    asserts.equals(env, "dep_a", info.module_name)
 
     return analysistest.end(env)
 
-def _top_explicit_test_impl(ctx):
-    """Test that an explicit top attribute is used."""
+def _module_name_default_test_impl(ctx):
+    """Test that module_name defaults to empty string when not specified."""
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
     info = target[VerilogInfo]
 
-    asserts.equals(env, "dep_a.sv", info.top.basename)
-
-    return analysistest.end(env)
-
-def _top_none_test_impl(ctx):
-    """Test that top is None when no resolution is possible."""
-    env = analysistest.begin(ctx)
-    target = analysistest.target_under_test(env)
-    info = target[VerilogInfo]
-
-    asserts.equals(env, None, info.top)
+    asserts.equals(env, "", info.module_name)
 
     return analysistest.end(env)
 
@@ -97,9 +87,8 @@ leaf_provider_test = analysistest.make(_leaf_provider_test_impl)
 transitive_deps_test = analysistest.make(_transitive_deps_test_impl)
 legacy_standard_test = analysistest.make(_legacy_standard_test_impl)
 explicit_includes_test = analysistest.make(_explicit_includes_test_impl)
-top_name_matching_test = analysistest.make(_top_name_matching_test_impl)
-top_explicit_test = analysistest.make(_top_explicit_test_impl)
-top_none_test = analysistest.make(_top_none_test_impl)
+module_name_explicit_test = analysistest.make(_module_name_explicit_test_impl)
+module_name_default_test = analysistest.make(_module_name_default_test_impl)
 bad_src_extension_test = analysistest.make(
     _bad_src_extension_test_impl,
     expect_failure = True,
@@ -131,18 +120,13 @@ def verilog_library_test_suite(name):
         target_under_test = ":with_includes",
     )
 
-    top_name_matching_test(
-        name = name + "_top_name_matching",
-        target_under_test = ":top",
+    module_name_explicit_test(
+        name = name + "_module_name_explicit",
+        target_under_test = ":explicit_module_name",
     )
 
-    top_explicit_test(
-        name = name + "_top_explicit",
-        target_under_test = ":explicit_top",
-    )
-
-    top_none_test(
-        name = name + "_top_none",
+    module_name_default_test(
+        name = name + "_module_name_default",
         target_under_test = ":utility_lib",
     )
 
@@ -158,9 +142,8 @@ def verilog_library_test_suite(name):
             name + "_transitive_deps",
             name + "_legacy_standard",
             name + "_explicit_includes",
-            name + "_top_name_matching",
-            name + "_top_explicit",
-            name + "_top_none",
+            name + "_module_name_explicit",
+            name + "_module_name_default",
             name + "_bad_src_extension",
         ],
     )

--- a/verilog/private/tests/verilog_library_analysis_test.bzl
+++ b/verilog/private/tests/verilog_library_analysis_test.bzl
@@ -17,6 +17,7 @@ def _leaf_provider_test_impl(ctx):
     asserts.equals(env, [], info.deps.to_list())
     asserts.equals(env, "", info.standard)
     asserts.equals(env, 1, len(info.includes.to_list()))
+    asserts.equals(env, "leaf.sv", info.top.basename)
 
     return analysistest.end(env)
 
@@ -57,6 +58,36 @@ def _explicit_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
+def _top_name_matching_test_impl(ctx):
+    """Test that top is resolved by matching basename to label name."""
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    info = target[VerilogInfo]
+
+    asserts.equals(env, "top.sv", info.top.basename)
+
+    return analysistest.end(env)
+
+def _top_explicit_test_impl(ctx):
+    """Test that an explicit top attribute is used."""
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    info = target[VerilogInfo]
+
+    asserts.equals(env, "dep_a.sv", info.top.basename)
+
+    return analysistest.end(env)
+
+def _top_none_test_impl(ctx):
+    """Test that top is None when no resolution is possible."""
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    info = target[VerilogInfo]
+
+    asserts.equals(env, None, info.top)
+
+    return analysistest.end(env)
+
 def _bad_src_extension_test_impl(ctx):
     env = analysistest.begin(ctx)
     asserts.expect_failure(env, "expected .v or .sv")
@@ -66,6 +97,9 @@ leaf_provider_test = analysistest.make(_leaf_provider_test_impl)
 transitive_deps_test = analysistest.make(_transitive_deps_test_impl)
 legacy_standard_test = analysistest.make(_legacy_standard_test_impl)
 explicit_includes_test = analysistest.make(_explicit_includes_test_impl)
+top_name_matching_test = analysistest.make(_top_name_matching_test_impl)
+top_explicit_test = analysistest.make(_top_explicit_test_impl)
+top_none_test = analysistest.make(_top_none_test_impl)
 bad_src_extension_test = analysistest.make(
     _bad_src_extension_test_impl,
     expect_failure = True,
@@ -97,6 +131,21 @@ def verilog_library_test_suite(name):
         target_under_test = ":with_includes",
     )
 
+    top_name_matching_test(
+        name = name + "_top_name_matching",
+        target_under_test = ":top",
+    )
+
+    top_explicit_test(
+        name = name + "_top_explicit",
+        target_under_test = ":explicit_top",
+    )
+
+    top_none_test(
+        name = name + "_top_none",
+        target_under_test = ":utility_lib",
+    )
+
     bad_src_extension_test(
         name = name + "_bad_src_extension",
         target_under_test = ":bad_src",
@@ -109,6 +158,9 @@ def verilog_library_test_suite(name):
             name + "_transitive_deps",
             name + "_legacy_standard",
             name + "_explicit_includes",
+            name + "_top_name_matching",
+            name + "_top_explicit",
+            name + "_top_none",
             name + "_bad_src_extension",
         ],
     )

--- a/verilog/private/tests/verilog_library_analysis_test.bzl
+++ b/verilog/private/tests/verilog_library_analysis_test.bzl
@@ -17,7 +17,7 @@ def _leaf_provider_test_impl(ctx):
     asserts.equals(env, [], info.deps.to_list())
     asserts.equals(env, "", info.standard)
     asserts.equals(env, 1, len(info.includes.to_list()))
-    asserts.equals(env, "", info.module_name)
+    asserts.equals(env, "", info.top_module)
 
     return analysistest.end(env)
 
@@ -58,23 +58,23 @@ def _explicit_includes_test_impl(ctx):
 
     return analysistest.end(env)
 
-def _module_name_explicit_test_impl(ctx):
-    """Test that an explicit module_name attribute is used."""
+def _top_module_explicit_test_impl(ctx):
+    """Test that an explicit top_module attribute is used."""
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
     info = target[VerilogInfo]
 
-    asserts.equals(env, "dep_a", info.module_name)
+    asserts.equals(env, "dep_a", info.top_module)
 
     return analysistest.end(env)
 
-def _module_name_default_test_impl(ctx):
-    """Test that module_name defaults to empty string when not specified."""
+def _top_module_default_test_impl(ctx):
+    """Test that top_module defaults to empty string when not specified."""
     env = analysistest.begin(ctx)
     target = analysistest.target_under_test(env)
     info = target[VerilogInfo]
 
-    asserts.equals(env, "", info.module_name)
+    asserts.equals(env, "", info.top_module)
 
     return analysistest.end(env)
 
@@ -87,8 +87,8 @@ leaf_provider_test = analysistest.make(_leaf_provider_test_impl)
 transitive_deps_test = analysistest.make(_transitive_deps_test_impl)
 legacy_standard_test = analysistest.make(_legacy_standard_test_impl)
 explicit_includes_test = analysistest.make(_explicit_includes_test_impl)
-module_name_explicit_test = analysistest.make(_module_name_explicit_test_impl)
-module_name_default_test = analysistest.make(_module_name_default_test_impl)
+top_module_explicit_test = analysistest.make(_top_module_explicit_test_impl)
+top_module_default_test = analysistest.make(_top_module_default_test_impl)
 bad_src_extension_test = analysistest.make(
     _bad_src_extension_test_impl,
     expect_failure = True,
@@ -120,13 +120,13 @@ def verilog_library_test_suite(name):
         target_under_test = ":with_includes",
     )
 
-    module_name_explicit_test(
-        name = name + "_module_name_explicit",
-        target_under_test = ":explicit_module_name",
+    top_module_explicit_test(
+        name = name + "_top_module_explicit",
+        target_under_test = ":explicit_top_module",
     )
 
-    module_name_default_test(
-        name = name + "_module_name_default",
+    top_module_default_test(
+        name = name + "_top_module_default",
         target_under_test = ":utility_lib",
     )
 
@@ -142,8 +142,8 @@ def verilog_library_test_suite(name):
             name + "_transitive_deps",
             name + "_legacy_standard",
             name + "_explicit_includes",
-            name + "_module_name_explicit",
-            name + "_module_name_default",
+            name + "_top_module_explicit",
+            name + "_top_module_default",
             name + "_bad_src_extension",
         ],
     )

--- a/verilog/verilog_info.bzl
+++ b/verilog/verilog_info.bzl
@@ -7,8 +7,8 @@ VerilogInfo = provider(
         "deps": "depset[VerilogInfo]: Transitive dependency providers.",
         "hdrs": "depset[File]: Verilog/SV header files for this target.",
         "includes": "depset[str]: Include search paths for this target.",
-        "module_name": "str: The top-level module name.",
         "srcs": "depset[File]: Verilog/SV source files for this target.",
         "standard": "str: Verilog/SystemVerilog standard version for this target.",
+        "top_module": "str: The top module of this library.",
     },
 )

--- a/verilog/verilog_info.bzl
+++ b/verilog/verilog_info.bzl
@@ -7,8 +7,8 @@ VerilogInfo = provider(
         "deps": "depset[VerilogInfo]: Transitive dependency providers.",
         "hdrs": "depset[File]: Verilog/SV header files for this target.",
         "includes": "depset[str]: Include search paths for this target.",
+        "module_name": "str: The top-level module name.",
         "srcs": "depset[File]: Verilog/SV source files for this target.",
         "standard": "str: Verilog/SystemVerilog standard version for this target.",
-        "module_name": "str: The top-level module name.",
     },
 )

--- a/verilog/verilog_info.bzl
+++ b/verilog/verilog_info.bzl
@@ -9,6 +9,6 @@ VerilogInfo = provider(
         "includes": "depset[str]: Include search paths for this target.",
         "srcs": "depset[File]: Verilog/SV source files for this target.",
         "standard": "str: Verilog/SystemVerilog standard version for this target.",
-        "top": "File or None: The source file representing the top module entry point. Basename (minus extension) is expected to match the module name. None for utility libraries with no single top.",
+        "module_name": "str: The top-level module name.",
     },
 )

--- a/verilog/verilog_info.bzl
+++ b/verilog/verilog_info.bzl
@@ -9,5 +9,6 @@ VerilogInfo = provider(
         "includes": "depset[str]: Include search paths for this target.",
         "srcs": "depset[File]: Verilog/SV source files for this target.",
         "standard": "str: Verilog/SystemVerilog standard version for this target.",
+        "top": "File or None: The source file representing the top module entry point. Basename (minus extension) is expected to match the module name. None for utility libraries with no single top.",
     },
 )

--- a/verilog/verilog_library.bzl
+++ b/verilog/verilog_library.bzl
@@ -2,51 +2,6 @@
 
 load(":verilog_info.bzl", "VerilogInfo")
 
-def _find_top(ctx, srcs, top = None):
-    """Determine the top module entry point from sources.
-
-    Resolution order: explicit `top` label > single src > src whose
-    basename (sans extension) matches `ctx.label.name` > None.
-
-    Args:
-        ctx: The rule's context object.
-        srcs: A list of File objects from `ctx.files.srcs`.
-        top: An explicit File contender for the top entry point, or None.
-
-    Returns:
-        File or None: The resolved top entry point, or None if one
-        could not be determined (e.g. a multi-source utility library).
-    """
-    if top:
-        if top not in srcs:
-            fail("`top` was not found in `srcs`. Please add `{}` to `srcs` for {}".format(
-                top.path,
-                ctx.label,
-            ))
-        return top
-
-    if len(srcs) == 1:
-        return srcs[0]
-
-    matched = None
-    for src in srcs:
-        basename = src.basename
-        if basename.endswith(".sv"):
-            basename = basename[:-3]
-        elif basename.endswith(".v"):
-            basename = basename[:-2]
-        else:
-            continue
-
-        if basename == ctx.label.name:
-            if matched:
-                fail("Multiple files match candidates for `top`. Please explicitly specify which to use for {}".format(
-                    ctx.label,
-                ))
-            matched = src
-
-    return matched
-
 def _verilog_library_impl(ctx):
     """Collects Verilog sources and transitive dependency info.
 
@@ -56,7 +11,6 @@ def _verilog_library_impl(ctx):
     Returns:
       A list of providers: VerilogInfo and DefaultInfo.
     """
-    top = _find_top(ctx, ctx.files.srcs, ctx.file.top)
 
     dep_infos = [dep[VerilogInfo] for dep in ctx.attr.deps]
 
@@ -73,7 +27,7 @@ def _verilog_library_impl(ctx):
             includes = depset(hdr_includes + pkg_includes),
             data = depset(ctx.files.data),
             standard = ctx.attr.standard,
-            top = top,
+            module_name = ctx.attr.module_name,
             deps = depset(dep_infos, order = "postorder", transitive = [d.deps for d in dep_infos]),
         ),
         DefaultInfo(files = depset(ctx.files.srcs + ctx.files.hdrs + ctx.files.data)),
@@ -110,9 +64,9 @@ verilog_library = rule(
             default = "",
             values = ["", "1995", "2001", "2005", "2009", "2012", "2017", "2023"],
         ),
-        "top": attr.label(
-            doc = "The top module entry point. If unset, resolved from a single src or a src whose basename matches the target name.",
-            allow_single_file = [".v", ".sv"],
+        "module_name": attr.string(
+            doc = "The top-level module name. Empty string means not specified.",
+            default = "",
         ),
     },
     provides = [VerilogInfo],

--- a/verilog/verilog_library.bzl
+++ b/verilog/verilog_library.bzl
@@ -55,6 +55,10 @@ verilog_library = rule(
             doc = "Additional include search paths, relative to this package.",
             default = [],
         ),
+        "module_name": attr.string(
+            doc = "The top-level module name. Empty string means not specified.",
+            default = "",
+        ),
         "srcs": attr.label_list(
             doc = "Verilog or SystemVerilog sources.",
             allow_files = [".v", ".sv"],
@@ -63,10 +67,6 @@ verilog_library = rule(
             doc = "Verilog/SystemVerilog standard version. Empty string means not specified; consumer rules apply their default.",
             default = "",
             values = ["", "1995", "2001", "2005", "2009", "2012", "2017", "2023"],
-        ),
-        "module_name": attr.string(
-            doc = "The top-level module name. Empty string means not specified.",
-            default = "",
         ),
     },
     provides = [VerilogInfo],

--- a/verilog/verilog_library.bzl
+++ b/verilog/verilog_library.bzl
@@ -27,7 +27,7 @@ def _verilog_library_impl(ctx):
             includes = depset(hdr_includes + pkg_includes),
             data = depset(ctx.files.data),
             standard = ctx.attr.standard,
-            module_name = ctx.attr.module_name,
+            top_module = ctx.attr.top_module,
             deps = depset(dep_infos, order = "postorder", transitive = [d.deps for d in dep_infos]),
         ),
         DefaultInfo(files = depset(ctx.files.srcs + ctx.files.hdrs + ctx.files.data)),
@@ -55,10 +55,6 @@ verilog_library = rule(
             doc = "Additional include search paths, relative to this package.",
             default = [],
         ),
-        "module_name": attr.string(
-            doc = "The top-level module name. Empty string means not specified.",
-            default = "",
-        ),
         "srcs": attr.label_list(
             doc = "Verilog or SystemVerilog sources.",
             allow_files = [".v", ".sv"],
@@ -67,6 +63,10 @@ verilog_library = rule(
             doc = "Verilog/SystemVerilog standard version. Empty string means not specified; consumer rules apply their default.",
             default = "",
             values = ["", "1995", "2001", "2005", "2009", "2012", "2017", "2023"],
+        ),
+        "top_module": attr.string(
+            doc = "The top module of this library. This is a local concept; the library's own entry-point module, not necessarily the global design top. Empty string means not specified.",
+            default = "",
         ),
     },
     provides = [VerilogInfo],

--- a/verilog/verilog_library.bzl
+++ b/verilog/verilog_library.bzl
@@ -2,6 +2,51 @@
 
 load(":verilog_info.bzl", "VerilogInfo")
 
+def _find_top(ctx, srcs, top = None):
+    """Determine the top module entry point from sources.
+
+    Resolution order: explicit `top` label > single src > src whose
+    basename (sans extension) matches `ctx.label.name` > None.
+
+    Args:
+        ctx: The rule's context object.
+        srcs: A list of File objects from `ctx.files.srcs`.
+        top: An explicit File contender for the top entry point, or None.
+
+    Returns:
+        File or None: The resolved top entry point, or None if one
+        could not be determined (e.g. a multi-source utility library).
+    """
+    if top:
+        if top not in srcs:
+            fail("`top` was not found in `srcs`. Please add `{}` to `srcs` for {}".format(
+                top.path,
+                ctx.label,
+            ))
+        return top
+
+    if len(srcs) == 1:
+        return srcs[0]
+
+    matched = None
+    for src in srcs:
+        basename = src.basename
+        if basename.endswith(".sv"):
+            basename = basename[:-3]
+        elif basename.endswith(".v"):
+            basename = basename[:-2]
+        else:
+            continue
+
+        if basename == ctx.label.name:
+            if matched:
+                fail("Multiple files match candidates for `top`. Please explicitly specify which to use for {}".format(
+                    ctx.label,
+                ))
+            matched = src
+
+    return matched
+
 def _verilog_library_impl(ctx):
     """Collects Verilog sources and transitive dependency info.
 
@@ -11,6 +56,8 @@ def _verilog_library_impl(ctx):
     Returns:
       A list of providers: VerilogInfo and DefaultInfo.
     """
+    top = _find_top(ctx, ctx.files.srcs, ctx.file.top)
+
     dep_infos = [dep[VerilogInfo] for dep in ctx.attr.deps]
 
     hdr_includes = [f.dirname for f in ctx.files.hdrs]
@@ -26,6 +73,7 @@ def _verilog_library_impl(ctx):
             includes = depset(hdr_includes + pkg_includes),
             data = depset(ctx.files.data),
             standard = ctx.attr.standard,
+            top = top,
             deps = depset(dep_infos, order = "postorder", transitive = [d.deps for d in dep_infos]),
         ),
         DefaultInfo(files = depset(ctx.files.srcs + ctx.files.hdrs + ctx.files.data)),
@@ -62,5 +110,10 @@ verilog_library = rule(
             default = "",
             values = ["", "1995", "2001", "2005", "2009", "2012", "2017", "2023"],
         ),
+        "top": attr.label(
+            doc = "The top module entry point. If unset, resolved from a single src or a src whose basename matches the target name.",
+            allow_single_file = [".v", ".sv"],
+        ),
     },
+    provides = [VerilogInfo],
 )


### PR DESCRIPTION
This is to avoid needing to parse this exact information in consumers of library targets.