### PR TITLE
Adds library field

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The primary goal of `rules_verilog` is to provide only the most **foundational**
 - `includes` — include search paths (auto-derived from `hdrs` locations + explicit paths)
 - `data` — data files needed during compilation or simulation
 - `deps` — other `verilog_library` targets
+- `library` — Verilog/SystemVerilog library name (defaults to the target's name)
 - `top_module` — the local top module of this library (optional; empty string means "unspecified")
 - `standard` — Verilog/SystemVerilog standard version (optional; empty string means "unspecified")
 
@@ -42,6 +43,7 @@ verilog_library(
     name = "core",
     srcs = ["core.sv"],
     hdrs = ["core_defines.svh"],
+    library = "my_core",
     standard = "2012",
 )
 

--- a/verilog/private/tests/BUILD.bazel
+++ b/verilog/private/tests/BUILD.bazel
@@ -50,6 +50,12 @@ verilog_library(
 )
 
 verilog_library(
+    name = "custom_lib_target",
+    srcs = ["dep_a.sv"],
+    library = "my_custom_lib",
+)
+
+verilog_library(
     name = "utility_lib",
     srcs = [
         "dep_a.sv",

--- a/verilog/private/tests/verilog_library_analysis_test.bzl
+++ b/verilog/private/tests/verilog_library_analysis_test.bzl
@@ -14,6 +14,7 @@ def _leaf_provider_test_impl(ctx):
     asserts.equals(env, ["leaf.sv"], _file_basenames(info.srcs.to_list()))
     asserts.equals(env, ["leaf.svh"], _file_basenames(info.hdrs.to_list()))
     asserts.equals(env, ["leaf.dat"], _file_basenames(info.data.to_list()))
+    asserts.equals(env, "leaf", info.library)
     asserts.equals(env, [], info.deps.to_list())
     asserts.equals(env, "", info.standard)
     asserts.equals(env, 1, len(info.includes.to_list()))
@@ -34,6 +35,17 @@ def _transitive_deps_test_impl(ctx):
     # Postorder guarantees dependencies before dependents (dep_a before dep_b).
     dep_src_order = [f.basename for d in dep_providers for f in d.srcs.to_list()]
     asserts.equals(env, ["dep_a.sv", "dep_b.sv"], dep_src_order)
+
+    return analysistest.end(env)
+
+def _custom_library_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    info = target[VerilogInfo]
+
+    asserts.equals(env, "my_custom_lib", info.library)
+    asserts.equals(env, "", info.standard)
+    asserts.equals(env, ["dep_a.sv"], _file_basenames(info.srcs.to_list()))
 
     return analysistest.end(env)
 
@@ -85,6 +97,7 @@ def _bad_src_extension_test_impl(ctx):
 
 leaf_provider_test = analysistest.make(_leaf_provider_test_impl)
 transitive_deps_test = analysistest.make(_transitive_deps_test_impl)
+custom_library_test = analysistest.make(_custom_library_test_impl)
 legacy_standard_test = analysistest.make(_legacy_standard_test_impl)
 explicit_includes_test = analysistest.make(_explicit_includes_test_impl)
 top_module_explicit_test = analysistest.make(_top_module_explicit_test_impl)
@@ -108,6 +121,11 @@ def verilog_library_test_suite(name):
     transitive_deps_test(
         name = name + "_transitive_deps",
         target_under_test = ":top",
+    )
+
+    custom_library_test(
+        name = name + "_custom_library",
+        target_under_test = ":custom_lib_target",
     )
 
     legacy_standard_test(
@@ -140,6 +158,7 @@ def verilog_library_test_suite(name):
         tests = [
             name + "_leaf_provider",
             name + "_transitive_deps",
+            name + "_custom_library",
             name + "_legacy_standard",
             name + "_explicit_includes",
             name + "_top_module_explicit",

--- a/verilog/verilog_info.bzl
+++ b/verilog/verilog_info.bzl
@@ -7,6 +7,7 @@ VerilogInfo = provider(
         "deps": "depset[VerilogInfo]: Transitive dependency providers.",
         "hdrs": "depset[File]: Verilog/SV header files for this target.",
         "includes": "depset[str]: Include search paths for this target.",
+        "library": "str: Verilog/SV library name for this target.",
         "srcs": "depset[File]: Verilog/SV source files for this target.",
         "standard": "str: Verilog/SystemVerilog standard version for this target.",
         "top_module": "str: The top module of this library.",

--- a/verilog/verilog_library.bzl
+++ b/verilog/verilog_library.bzl
@@ -25,6 +25,7 @@ def _verilog_library_impl(ctx):
             srcs = depset(ctx.files.srcs),
             hdrs = depset(ctx.files.hdrs),
             includes = depset(hdr_includes + pkg_includes),
+            library = ctx.attr.library or ctx.label.name,
             data = depset(ctx.files.data),
             standard = ctx.attr.standard,
             top_module = ctx.attr.top_module,
@@ -62,6 +63,10 @@ verilog_library = rule(
         "includes": attr.string_list(
             doc = "Additional include search paths, relative to this package.",
             default = [],
+        ),
+        "library": attr.string(
+            doc = "Verilog/SystemVerilog library name this target compiles into. Defaults to the target's name.",
+            default = "",
         ),
         "srcs": attr.label_list(
             doc = "Verilog or SystemVerilog sources.",


### PR DESCRIPTION
This PR adds a new field, `library`, to the `VerilogInfo` provider. Its implementation is largely copied from the `VhdlInfo` provider's implementation in [rules_vhdl](https://github.com/hw-bzl/rules_vhdl). 

To verify this change works, a new test `//verilog/private/tests:verilog_library_tests_custom_library` is created to check against custom library names, and the test `//verilog/private/tests:verilog_library_tests_leaf_provider` is updated to check for the default value of the library if none is explicitly set in a `BUILD.bazel` file.

Closes #13.